### PR TITLE
Increase modified count if comment is modified

### DIFF
--- a/drf_spirit/models.py
+++ b/drf_spirit/models.py
@@ -131,3 +131,16 @@ class Comment(models.Model):
     def decrease_likes_count(self):
         (Comment.objects.filter(pk=self.pk, likes_count__gt=0)
                         .update(likes_count=F('likes_count') - 1))
+
+    def save(self, *args, **kwargs):
+        # Comment has pk, means the comment is modified. So increase modified_count and change is_modified
+        if self.pk:
+            self.is_modified = True
+            self.modified_count = F('modified_count') + 1
+
+        super(Comment, self).save(*args, **kwargs)
+
+        if self.pk:
+            # comment has pk means modified_count is changed.
+            # As we use F expression, its not possible to know modified_count until refresh from db
+            self.refresh_from_db()

--- a/drf_spirit/signals.py
+++ b/drf_spirit/signals.py
@@ -7,11 +7,10 @@ from .models import Comment
 
 @receiver(post_save, sender=Comment)
 def post_comment_save(sender, instance, created, **kwargs):
-    # Need to send emails to topic people
-    send_email_to_topic_people(instance, created)
-
-    # need to update *comment_count of topic if the comment is created
     if created:
+        # Need to send emails to topic people
+        send_email_to_topic_people(instance, created)
+        # need to update *comment_count of topic if the comment is created
         instance.topic.increase_comment_count()
 
 


### PR DESCRIPTION
Need to override ``save()`` of ``Comment`` because it needs to be updated before comment is going to saved.
Could not use signals for this use case
Moreover, need to research and add ``refresh_from_db()`` otherwise it will raise error.
r? @alaminopu 